### PR TITLE
Add a simple benchmark runner

### DIFF
--- a/.buildbot.config.toml
+++ b/.buildbot.config.toml
@@ -1,0 +1,17 @@
+# Config file for continuous integration.
+
+[rust]
+codegen-units = 0           # Use many compilation units.
+debug-assertions = true     # Turn on assertions in rustc.
+
+[build]
+docs = false
+extended = false
+
+[llvm]
+assertions = true           # Turn on assertions in LLVM.
+use-linker = "gold"         # Uses less memory than ld.
+
+[install]
+prefix = "build/rustc_boehm"
+sysconfdir = "etc"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Build script for continuous integration.
+
+set -e
+
+export CARGO_HOME="`pwd`/.cargo"
+export RUSTUP_HOME="`pwd`/.rustup"
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly -y --no-modify-path
+
+export PATH=`pwd`/.cargo/bin/:$PATH
+
+# Sometimes rustfmt is so broken that there is no way to install it at all.
+# Rather than refusing to merge, we just can't rust rustfmt at such a point.
+rustup component add --toolchain nightly rustfmt-preview \
+    || cargo +nightly install --force rustfmt-nightly \
+    || true
+rustfmt=0
+cargo fmt 2>&1 | grep "not installed for the toolchain" > /dev/null || rustfmt=1
+if [ $rustfmt -eq 1 ]; then
+    cargo +nightly fmt --all -- --check
+fi
+
+# needed to build benchmarks
+cargo install cargo-script
+
+# Build rustc_boehm
+git clone https://github.com/softdevteam/rustc_boehm
+mkdir -p rustc_boehm/build/rustc_boehm
+(cd rustc_boehm && ./x.py install --config ../.buildbot.config.toml)
+
+# Run the benchmarks. For now, simply running them successfully is enough to
+# pass the CI checks.
+RUSTC_BOEHM=rustc_boehm/build/rustc_boehm/bin/rustc cargo run --release
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gc_bench"
+version = "0.1.0"
+authors = ["Jacob Hughes <jh@jakehughes.uk>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.6"
+statistical = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# gc_bench
+
+This is a series of benchmarks designed to compare two ports of the
+Boehm-Demers-Weiser GC which provide opt-in Gc support in Rust:
+ * [rboehm](https://github.com/softdevteam/rboehm)
+ * [rustc_boehm](https://github.com/softdevteam/rustc_boehm)
+

--- a/benchmarks/bench_rboehm_vec_loop.rs
+++ b/benchmarks/bench_rboehm_vec_loop.rs
@@ -1,0 +1,25 @@
+//! ```cargo
+//! [dependencies]
+//! rboehm = { git = "https://github.com/softdevteam/rboehm" }
+//! ```
+extern crate rboehm;
+
+use rboehm::gc::Gc;
+use rboehm::BoehmAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: BoehmAllocator = BoehmAllocator;
+
+#[derive(Clone)]
+struct S {
+    x: usize,
+}
+
+fn main() {
+    let mut x: Vec<S> = Vec::with_capacity(1);
+    x.push(S { x: 123 });
+
+    for _ in 0..5000000 {
+        let _obj = Gc::new(x.clone());
+    }
+}

--- a/benchmarks/bench_rustc_vec_loop.rs
+++ b/benchmarks/bench_rustc_vec_loop.rs
@@ -1,0 +1,25 @@
+#![feature(allocator_api)]
+#![feature(gc)]
+
+use std::gc::Gc;
+use std::alloc::Boehm;
+use std::gc::ManageableContents;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: Boehm = Boehm;
+
+#[derive(Clone)]
+struct S {
+    x: usize,
+}
+
+impl ManageableContents for S {}
+
+fn main() {
+    let mut x: Vec<S> = Vec::with_capacity(1);
+    x.push(S { x: 123 });
+
+    for _ in 0..5000000 {
+        let _obj = Gc::new(x.clone());
+    }
+}

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+# The service providing the commit statuses to GitHub.
+status = ["buildbot/buildbot-build-script"]
+
+# Allow eight hours for builds + tests.
+timeout_sec = 28800
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,48 @@
+use std::{
+    env,
+    fs::read_dir,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn compile(benchmark: &Path) {
+    let stem = benchmark.file_stem().unwrap().to_str().unwrap();
+    let rustc = env::var("RUSTC_BOEHM").expect("RUSTC_BOEHM environment var not specified");
+    if stem.starts_with("bench_rustc") {
+        Command::new("cargo")
+            .args(&["script", benchmark.to_str().unwrap(), "--build-only"])
+            .env("RUSTC", rustc.as_str())
+            .output()
+            .expect(format!("Failed to compile benchmark: {}", stem).as_str());
+    } else if stem.starts_with("bench_rboehm") {
+        Command::new("cargo")
+            .args(&["script", benchmark.to_str().unwrap(), "--build-only"])
+            .output()
+            .expect(format!("Failed to compile benchmark: {}", stem).as_str());
+    } else {
+        panic!("Unable to compile benchmark {} - unknown compiler specified");
+    };
+
+    let mut bin = PathBuf::from(env::var("CARGO_HOME").unwrap());
+    bin.push("binary-cache");
+    bin.push("release");
+    bin.push(&stem);
+
+    let mut target = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    target.push("target");
+    #[cfg(debug_assertions)]
+    target.push("debug");
+    #[cfg(not(debug_assertions))]
+    target.push("release");
+
+    Command::new("mv")
+        .args(&[bin, target])
+        .spawn()
+        .expect("Couldn't move bin");
+}
+
+fn main() {
+    for bm in read_dir("benchmarks/").unwrap() {
+        compile(bm.unwrap().path().as_path());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,82 @@
+use std::{
+    collections::HashMap,
+    fs::read_dir,
+    io::{self, Write},
+    process::Command,
+    time::Instant,
+};
+
+use rand::{seq::SliceRandom, thread_rng};
+use statistical::{mean, standard_deviation};
+
+const REPS_DEFAULT: usize = 2;
+const ITERS: usize = 2;
+
+#[inline(never)]
+fn time(benchmark: &str) -> String {
+    let mut bin = Command::new(format!("target/release/{}", benchmark));
+    let before = Instant::now();
+    for _ in 0..ITERS {
+        bin.output().expect(&format!("Couldn't run {}", benchmark));
+    }
+    let d = Instant::now() - before;
+    String::from(format!(
+        "{:?}",
+        d.as_secs() as f64 + d.subsec_nanos() as f64 * 1e-9
+    ))
+}
+
+fn mean_ci(d: &Vec<f64>) -> (f64, f64) {
+    let m = mean(d);
+    let sd = standard_deviation(d, None);
+    // Calculate a 99% confidence based on the mean and standard deviation.
+    (m, 2.58 * (sd / (d.len() as f64).sqrt()))
+}
+
+fn main() {
+    let bmark_names = read_dir("benchmarks")
+        .unwrap()
+        .map(|x| {
+            x.unwrap()
+                .path()
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+
+    let mut bmark_data: HashMap<_, Vec<f64>> = HashMap::new();
+    for bn in &bmark_names {
+        bmark_data.insert(bn, vec![]);
+    }
+    let mut rng = thread_rng();
+    let mut done = 0;
+
+    let reps = REPS_DEFAULT;
+
+    while done < bmark_names.len() * reps {
+        // Randomly select a benchmark to run next
+        let bn = loop {
+            let cnd = bmark_names.choose(&mut rng).unwrap();
+            if bmark_data[cnd].len() < reps {
+                break cnd;
+            }
+        };
+
+        let stdout = time(&bn);
+        let t = stdout.trim().parse::<f64>().unwrap();
+        bmark_data.get_mut(&bn).unwrap().push(t);
+        done += 1;
+        print!(".");
+        io::stdout().flush().ok();
+    }
+    println!();
+    let mut bmark_names_sorted = bmark_names.clone();
+    bmark_names_sorted.sort();
+    for bn in &bmark_names_sorted {
+        let (mean, ci) = mean_ci(&bmark_data[&bn]);
+        println!("{}: {:.3} +/- {:.4}", bn, mean, ci);
+    }
+}


### PR DESCRIPTION
This PR sets up a benchmark runner which lets us compare `rustc_boehm` and `rboehm`. It includes three main things:

- A build script to compile each benchmark for `rustc_boehm` or `rboehm`. It is assumed that the user has installed `rustc_boehm` on their system, and will provide this to the build script using the `RUSTC_BOEHM=/path/to/rustc_boehm` environment variable. It makes use of `cargo-script` to do the fiddly (and frankly uninteresting) crate linkage for us.
- A very basic benchmark runner to run our compiled benchmarks. Much of the code for the actual runner (`src/main.rs`) should look very familiar to you -- it's _heavily_ inspired (stolen) from `vtable_bench`!
- An initial synthetic benchmark to compare both ports by allocating lots of `Vecs` in a tight-loop. The point of this is to test how well our finalizer optimisation in `rustc_boehm` works. Benchmarks are delegated to the relevant compiler in the build script based on the `bench_rustc` / `bench_rboehm` prefix in their name.

Initially things look pretty good. On my machine the results of the benchmark are as follows:
```
....
bench_rboehm_vec_loop: 4.973 +/- 0.1647
bench_rustc_vec_loop: 1.300 +/- 0.0554
```

Obviously this isn't very scientific but it's a good starting point I think.